### PR TITLE
feat: add unit tests for network message constants, enums, and models

### DIFF
--- a/test/domain/constants/network_message_constants_test.dart
+++ b/test/domain/constants/network_message_constants_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jogo_da_velha/domain/constants/network_message_constants.dart';
+
+void main() {
+  test('NetworkMessageConstants.peerConnected uses expected protocol value', () {
+    expect(NetworkMessageConstants.peerConnected, 'CONNECTED');
+  });
+}

--- a/test/domain/enums/domain_enums_test.dart
+++ b/test/domain/enums/domain_enums_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jogo_da_velha/domain/enums/connection_message_enum.dart';
+import 'package:jogo_da_velha/domain/enums/game_message_type_enum.dart';
+import 'package:jogo_da_velha/domain/enums/online_options_flow_enum.dart';
+import 'package:jogo_da_velha/domain/enums/player_role_enum.dart';
+import 'package:jogo_da_velha/domain/enums/routes_enum.dart';
+
+void main() {
+  group('ConnectionMessageEnum.tryParse', () {
+    test('returns enum when message is valid', () {
+      expect(
+        ConnectionMessageEnum.tryParse('SERVER_CONNECTED'),
+        ConnectionMessageEnum.serverConnected,
+      );
+    });
+
+    test('returns null when message is invalid', () {
+      expect(ConnectionMessageEnum.tryParse('UNKNOWN'), isNull);
+    });
+  });
+
+  group('GameMessageTypeEnum.tryParse', () {
+    test('returns enum when value is valid', () {
+      expect(
+        GameMessageTypeEnum.tryParse('requestMove'),
+        GameMessageTypeEnum.requestMove,
+      );
+    });
+
+    test('returns null when value is null or invalid', () {
+      expect(GameMessageTypeEnum.tryParse(null), isNull);
+      expect(GameMessageTypeEnum.tryParse('invalid'), isNull);
+    });
+  });
+
+  group('PlayerRole getters', () {
+    test('isHost and isGuest match enum variant', () {
+      expect(PlayerRole.host.isHost, isTrue);
+      expect(PlayerRole.host.isGuest, isFalse);
+      expect(PlayerRole.guest.isHost, isFalse);
+      expect(PlayerRole.guest.isGuest, isTrue);
+    });
+  });
+
+  group('Routes and flow enums', () {
+    test('routes have expected paths', () {
+      expect(RoutesEnum.splash.path, '/');
+      expect(RoutesEnum.menu.path, '/menu');
+      expect(RoutesEnum.localGame.path, '/local-game');
+      expect(RoutesEnum.onlineGame.path, '/online-game');
+    });
+
+    test('online flow enum keeps expected order', () {
+      expect(
+        OnlineOptionsFlowEnum.values,
+        [
+          OnlineOptionsFlowEnum.idle,
+          OnlineOptionsFlowEnum.creatingServer,
+          OnlineOptionsFlowEnum.serverReady,
+          OnlineOptionsFlowEnum.connecting,
+          OnlineOptionsFlowEnum.connectedNavigating,
+        ],
+      );
+    });
+  });
+}

--- a/test/domain/models/network_connection_model_test.dart
+++ b/test/domain/models/network_connection_model_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jogo_da_velha/domain/enums/connection_status_enum.dart';
+import 'package:jogo_da_velha/domain/models/network_connection_model.dart';
+
+void main() {
+  group('NetworkConnectionModel', () {
+    test('starts disconnected by default', () {
+      final model = NetworkConnectionModel();
+
+      expect(model.status, ConnectionStatusEnum.disconnected);
+      expect(model.errorMessage, isNull);
+    });
+
+    test('accepts custom status and error message', () {
+      final model = NetworkConnectionModel(
+        status: ConnectionStatusEnum.error,
+        errorMessage: 'connection failed',
+      );
+
+      expect(model.status, ConnectionStatusEnum.error);
+      expect(model.errorMessage, 'connection failed');
+    });
+  });
+}

--- a/test/domain/models/online_tic_tac_toe_game_model_test.dart
+++ b/test/domain/models/online_tic_tac_toe_game_model_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jogo_da_velha/data/dtos/online_tic_tac_toe_game_dto.dart';
+import 'package:jogo_da_velha/domain/enums/player_enum.dart';
+import 'package:jogo_da_velha/domain/enums/winning_line_enum.dart';
+import 'package:jogo_da_velha/domain/models/online_tic_tac_toe_game_model.dart';
+import 'package:jogo_da_velha/presentation/models/winning_line_model.dart';
+
+void main() {
+  group('OnlineTicTacToeGameModel', () {
+    test('creates default state', () {
+      final model = OnlineTicTacToeGameModel();
+
+      expect(model.board.length, 3);
+      expect(model.board.every((row) => row.length == 3), isTrue);
+      expect(model.currentPlayer, PlayerEnum.x);
+      expect(model.maxRounds, 5);
+      expect(model.winner, isNull);
+      expect(model.winningLine, isNull);
+      expect(model.isGameOver, isFalse);
+    });
+
+    test('fromDto maps board and winning line correctly', () {
+      const dto = OnlineTicTacToeGameDTO(
+        board: [
+          ['x', 'o', 'none'],
+          ['none', 'x', 'o'],
+          ['none', 'none', 'x'],
+        ],
+        currentPlayer: 'o',
+        winner: 'x',
+        winningLine: {'type': 'diagonalMain', 'index': null},
+        isGameOver: true,
+        scoreX: 2,
+        scoreO: 1,
+        currentRound: 3,
+        maxRounds: 7,
+      );
+
+      final model = OnlineTicTacToeGameModel.fromDto(dto);
+
+      expect(model.board[0][0], PlayerEnum.x);
+      expect(model.board[0][1], PlayerEnum.o);
+      expect(model.board[0][2], PlayerEnum.none);
+      expect(model.currentPlayer, PlayerEnum.o);
+      expect(model.winner, PlayerEnum.x);
+      expect(model.winningLine?.type, WinningLineEnum.diagonalMain);
+      expect(model.isGameOver, isTrue);
+      expect(model.scoreX, 2);
+      expect(model.scoreO, 1);
+      expect(model.currentRound, 3);
+      expect(model.maxRounds, 7);
+    });
+
+    test('toDto maps enum values back to DTO payload', () {
+      final model = OnlineTicTacToeGameModel.fromValues(
+        board: [
+          [PlayerEnum.x, PlayerEnum.o, PlayerEnum.none],
+          [PlayerEnum.none, PlayerEnum.x, PlayerEnum.o],
+          [PlayerEnum.none, PlayerEnum.none, PlayerEnum.x],
+        ],
+        currentPlayer: PlayerEnum.o,
+        winner: PlayerEnum.x,
+        winningLine: WinningLineModel.diagonalMain(),
+        isGameOver: true,
+        scoreX: 3,
+        scoreO: 2,
+        currentRound: 5,
+        maxRounds: 9,
+      );
+
+      final dto = model.toDto();
+
+      expect(dto.board[0][0], 'x');
+      expect(dto.board[0][1], 'o');
+      expect(dto.board[0][2], 'none');
+      expect(dto.currentPlayer, 'o');
+      expect(dto.winner, 'x');
+      expect(dto.winningLine?['type'], 'diagonalMain');
+      expect(dto.isGameOver, isTrue);
+      expect(dto.scoreX, 3);
+      expect(dto.scoreO, 2);
+      expect(dto.currentRound, 5);
+      expect(dto.maxRounds, 9);
+    });
+
+    test('copyWith can clear winner and winning line', () {
+      final base = OnlineTicTacToeGameModel.fromValues(
+        board: List.generate(3, (_) => List.generate(3, (_) => PlayerEnum.none)),
+        currentPlayer: PlayerEnum.x,
+        winner: PlayerEnum.o,
+        winningLine: WinningLineModel.horizontal(0),
+        isGameOver: true,
+        scoreX: 0,
+        scoreO: 1,
+        currentRound: 2,
+        maxRounds: 5,
+      );
+
+      final updated = base.copyWith(
+        clearWinner: true,
+        clearWinningLine: true,
+        isGameOver: false,
+      );
+
+      expect(updated.winner, isNull);
+      expect(updated.winningLine, isNull);
+      expect(updated.isGameOver, isFalse);
+      expect(updated.currentPlayer, PlayerEnum.x);
+    });
+  });
+}


### PR DESCRIPTION
- Introduced unit tests for NetworkMessageConstants to validate protocol values.
- Added comprehensive tests for various enums including ConnectionMessageEnum, GameMessageTypeEnum, and PlayerRole.
- Implemented tests for NetworkConnectionModel to verify default states and custom values.
- Created tests for OnlineTicTacToeGameModel to ensure correct state initialization, DTO mapping, and functionality of copyWith method.